### PR TITLE
Add basic README and API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,58 @@
+# SubclassesTrackerExtension
+
+This repository contains an ASP.NET Core API for retrieving and processing
+ESO Logs data. It interacts with the official ESO Logs GraphQL API to fetch
+reports, fights, players and buff information for Elder Scrolls Online.
+
+## Features
+
+- OAuth authentication flow to obtain access tokens for the ESO Logs API.
+- GraphQL client powered by Strawberry Shake.
+- Endpoints for retrieving fights, players and buffs for a given log.
+- Background service for collecting logs over time.
+- Tools for generating Excel reports with skill line statistics.
+
+## Building
+
+The project targets **.NET 9.0**. Make sure the appropriate .NET SDK is
+installed and run:
+
+```bash
+ dotnet restore
+ dotnet build
+```
+
+Some functionality depends on the `SubclassesTracker.Database` project which is
+referenced in the solution but not included in this repository.
+
+## Configuration
+
+Application settings are stored in `appsettings.json`. Important values are
+nested under the `LinesConfig` section:
+
+```json
+{
+  "LinesConfig": {
+    "ClientId": "<ESO Logs OAuth client id>",
+    "TrialStartTimeSlice": 0,
+    "TokenFilePath": "./Saves/token.json",
+    "EsoLogsApiUrl": "https://www.esologs.com/api/v2/",
+    "LocalCallBackOAuthUri": "https://localhost:7192/auth/callback",
+    "AuthEndpoint": "https://www.esologs.com/oauth/authorize",
+    "TokenEndpoint": "https://www.esologs.com/oauth/token",
+    "SkillLinesDb": "Lines/skillTree.db"
+  }
+}
+```
+
+## Usage
+
+Once running, the following routes are available under `/api/skill`:
+
+- `GET /getFights?logId=<log>` – list fight identifiers for a log
+- `GET /getPlayers?logId=<log>` – list players and roles for a log
+- `GET /getPlayerBuffs?logId=<log>&playerId=<id>` – buff data for a player
+- `GET /getAllReports` – fetch recent reports and their fights
+
+See the [documentation](docs/API.md) for more details.
+

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,27 @@
+# API Endpoints
+
+The API exposes several routes for accessing ESO Logs data. All routes are
+prefixed with `/api/skill`.
+
+## `GET /getFights`
+Returns a list of fight identifiers for the specified log.
+
+Query parameters:
+- `logId` – identifier of the log in ESO Logs.
+
+## `GET /getPlayers`
+Returns players and their roles for a log. Requires the list of fight IDs
+internally.
+
+Query parameters:
+- `logId` – log identifier.
+
+## `GET /getPlayerBuffs`
+Retrieves buff information for a specific player.
+
+Query parameters:
+- `logId` – log identifier.
+- `playerId` – player identifier from the log.
+
+## `GET /getAllReports`
+Fetches reports for known zones and difficulties and lists their fights.


### PR DESCRIPTION
## Summary
- document project purpose and setup in a new `README.md`
- describe available endpoints under `docs/API.md`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68651644d484832e8934ed3f68bf02dd