### PR TITLE
Add release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Build and Deploy
+
+on:
+  push:
+    branches:
+      - release
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Restore dependencies
+        run: dotnet restore SubclassesTrackerExtension.sln
+
+      - name: Publish
+        run: dotnet publish SubclassesTracker.Api.csproj -c Release -o publish
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: SubclassesTracker.Api
+          path: publish
+
+      - name: Deploy to yokocodev.site
+        uses: appleboy/scp-action@v0.1.4
+        with:
+          host: ${{ secrets.YOKO_HOST }}
+          username: ${{ secrets.YOKO_USER }}
+          key: ${{ secrets.YOKO_KEY }}
+          target: ${{ secrets.YOKO_TARGET }}
+          source: "publish/*"


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build SubclassesTracker.Api when pushing to the `release` branch
- publish the app and upload artifacts
- deploy to `yokocodev.site` using `appleboy/scp-action`, expecting secrets for connection details

## Testing
- `dotnet build SubclassesTracker.Api.csproj` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880c4e5c9a4832ea8605a258878113f