### PR TITLE
Add release-based extension instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ cd backend
 
 Alternatively, skip this step and use the API instance already running on the remote host.
 
-3. Download the latest browser extension from the [releases page](https://github.com/YourHopelessness/SubclassesTrackerAPI/releases).
+3. **You need to create your own OAuth client [here](https://www.esologs.com/api/clients)**. The client id is required by the extension. When creating the client check the *PKCE* option and add `https://mpldcmnhbilholjaopjhcjfhcimgehjf.chromiumapp.org/` as a redirect URL.
+4. Download the latest browser extension from the [releases page](https://github.com/YourHopelessness/SubclassesTrackerAPI/releases).
 
 ## Loading the extension unpacked
 

--- a/README.md
+++ b/README.md
@@ -10,13 +10,15 @@ The backend and extension can be used together or separately. See the individual
 ## Quick start
 
 1. Clone the repository and install the dependencies for each project.
-2. Build and run the backend service:
+2. *(Optional)* run the backend locally. The API is already hosted remotely so this step can be skipped:
 
 ```bash
 cd backend
  dotnet restore
  dotnet run
 ```
+
+Alternatively, skip this step and use the API instance already running on the remote host.
 
 3. Download the latest browser extension from the [releases page](https://github.com/YourHopelessness/SubclassesTrackerAPI/releases).
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,34 @@
+# Subclasses Tracker
+
+This repository contains two projects:
+
+- **backend/** – ASP.NET Core API (`SubclassesTrackerExtension`) that queries the official ESO Logs GraphQL API and exposes a simplified REST API for collecting skill line data.
+- **frontend/** – browser extension built with Vite and TypeScript. It injects additional subclass information into the ESO Logs website using data from the backend API.
+
+The backend and extension can be used together or separately. See the individual READMEs in each directory for full details.
+
+## Quick start
+
+1. Clone the repository and install the dependencies for each project.
+2. Build and run the backend service:
+
+```bash
+cd backend
+ dotnet restore
+ dotnet run
+```
+
+3. Download the latest browser extension from the [releases page](https://github.com/YourHopelessness/SubclassesTrackerAPI/releases).
+
+## Loading the extension unpacked
+
+After downloading the extension you can load it directly in your browser without packaging:
+
+- **Chrome / Chromium**: open `chrome://extensions`, enable *Developer mode* and click **Load unpacked**. Select the unzipped extension folder.
+- **Firefox**: open `about:debugging#/runtime/this-firefox`, choose **Load Temporary Add-on** and select the `manifest.json` file from the unzipped extension folder.
+
+For more details see [`docs/extension_installation.md`](docs/extension_installation.md).
+
+## Documentation
+
+Additional documentation is stored under the `docs/` folder and within each subproject.

--- a/backend/README.md
+++ b/backend/README.md
@@ -4,6 +4,8 @@ This repository contains an ASP.NET Core API for retrieving and processing
 ESO Logs data. It interacts with the official ESO Logs GraphQL API to fetch
 reports, fights, players and buff information for Elder Scrolls Online.
 
+The API is also deployed on a remote host, so running it locally is optional if you only need to consume the service.
+
 ## Features
 
 - OAuth authentication flow to obtain access tokens for the ESO Logs API.

--- a/backend/README.md
+++ b/backend/README.md
@@ -9,7 +9,6 @@ The API is also deployed on a remote host, so running it locally is optional if 
 ## Features
 
 - OAuth authentication flow to obtain access tokens for the ESO Logs API.
-- GraphQL client powered by Strawberry Shake.
 - Endpoints for retrieving fights, players and buffs for a given log.
 - Background service for collecting logs over time.
 - Tools for generating Excel reports with skill line statistics.
@@ -36,24 +35,39 @@ nested under the `LinesConfig` section:
     "TrialStartTimeSlice": 0,
     "TokenFilePath": "./Saves/token.json",
     "EsoLogsApiUrl": "https://www.esologs.com/api/v2/",
-    "LocalCallBackOAuthUri": "https://localhost:7192/auth/callback",
     "AuthEndpoint": "https://www.esologs.com/oauth/authorize",
     "TokenEndpoint": "https://www.esologs.com/oauth/token",
     "SkillLinesDb": "Lines/skillTree.db"
   }
 }
 ```
-You can create your own OAuth client [https://www.esologs.com/api/clients](here) 
+YOU NEED to create your own OAuth client [here](https://www.esologs.com/api/clients)
 ![image](https://github.com/user-attachments/assets/5c596b6c-2d00-42c2-96cf-57a0d1725d5b)
 
 ## Usage
 
-Once running, the following routes are available under `/api/skill`:
+Once running, the API exposes multiple route groups.
 
-- `GET /getFights?logId=<log>` – list fight identifiers for a log
-- `GET /getPlayers?logId=<log>` – list players and roles for a log
-- `GET /getPlayerBuffs?logId=<log>&playerId=<id>` – buff data for a player
-- `GET /getAllReports` – fetch recent reports and their fights
+### `/api/skill`
+* `GET /getFights?logId=<log>` – list fight identifiers for a log
+* `GET /getPlayers?logId=<log>` – list players and roles for a log
+* `GET /getPlayerBuffs?logId=<log>&playerId=<id>` – buff data for a player
+* `GET /getPlayersLines?logId=<log>&fightId=<fight>&bossId=<boss>&wipes=<n>` – skill lines for players
+* `GET /getAllReports` – fetch recent reports and their fights
+
+### `/api/job`
+* `POST /create?jobType=<type>` – queue a new job
+* `GET /{id}` – job status
+* `GET /{id}/result` – download job result
+* `GET /getAll` – list all jobs
+
+### `/api/oauth`
+* `GET /url?clientId=<id>&redirectUrl=<url>` – OAuth redirect URL
+* `POST /exchange` – exchange code for tokens
+* `POST /refresh` – refresh access token
+
+### `/api/healthcheck`
+* `GET /api/healthcheck` – check service status
 
 See the [documentation](docs/API.md) for more details.
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -55,3 +55,4 @@ Once running, the following routes are available under `/api/skill`:
 
 See the [documentation](docs/API.md) for more details.
 
+Pre-built extension packages are available on the [releases page](https://github.com/YourHopelessness/SubclassesTrackerAPI/releases). See [../docs/extension_installation.md](../docs/extension_installation.md) for installation instructions.

--- a/docs/extension_installation.md
+++ b/docs/extension_installation.md
@@ -1,0 +1,16 @@
+# Installing the Extension Unpacked
+
+Download the latest extension build from the [project releases](https://github.com/YourHopelessness/SubclassesTrackerAPI/releases) and extract the archive to a folder on your machine.
+
+## Chrome / Chromium
+1. Navigate to `chrome://extensions` in the browser.
+2. Enable **Developer mode** using the toggle in the top-right corner.
+3. Click **Load unpacked** and select the folder where you extracted the extension.
+
+## Firefox
+1. Navigate to `about:debugging#/runtime/this-firefox`.
+2. Click **Load Temporary Add-on**.
+3. Select the `manifest.json` file inside the extracted folder.
+
+The extension will then be loaded and can be used immediately.
+

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,19 @@
+# Frontend Extension
+
+This directory contains a browser extension that augments the ESO Logs website with additional subclass information. The extension communicates with the backend API to retrieve skill line data.
+
+## Development
+
+```bash
+npm install
+npm run dev
+```
+
+Running `npm run dev` uses Vite to watch the source files and rebuild the extension into the `dist` directory.
+
+
+Pre-built extension packages are available on the [releases page](https://github.com/YourHopelessness/SubclassesTrackerAPI/releases).
+
+## Loading the extension
+
+See the [installation guide](../docs/extension_installation.md) for instructions on loading the build as an unpacked extension in Chrome or Firefox.


### PR DESCRIPTION
## Summary
- update root README to point to releases instead of manual build
- clarify extension install doc with download instructions
- remove build section from frontend README
- mention releases page in backend docs

## Testing
- `npm run build` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6881f93c7164832e8b4fcb4022233214